### PR TITLE
Add metadata and JSON-LD schema to curated links page

### DIFF
--- a/src/app/curated-links/page.tsx
+++ b/src/app/curated-links/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 0;
+export const revalidate = 60; // Revalidate every minute
 
 import React from "react";
 import {
@@ -11,6 +11,20 @@ import {
 } from "./utils/discordApi";
 import CuratedLinksTabs from "@/app/curated-links/components/CuratedLinksTabs";
 import { NewsletterSignup } from "./components/NewsletterSignup";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Curated Links | SouravInsights",
+  description:
+    "A constantly updating digital garden of design inspiration, dev tools, portfolios, newsletters, career opportunities, and must-read articles curated from my Discord community.",
+  openGraph: {
+    title: "Curated Links | My Digital Garden",
+    description:
+      "A constantly updating digital garden of design inspiration, dev tools, portfolios, newsletters, career opportunities, and must-read articles.",
+    type: "website",
+    url: "https://www.souravinsights.com/curated-links",
+  },
+};
 
 async function getDiscordData() {
   const channels = await getChannels();
@@ -32,8 +46,33 @@ async function getDiscordData() {
 
 export default async function CuratedLinksPage() {
   const { channels, linkData } = await getDiscordData();
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Curated Links | My Digital Garden",
+    description: "A constantly updating digital garden of design inspiration, dev tools, portfolios, newsletters, career opportunities, and must-read articles.",
+    url: "https://www.souravinsights.com/curated-links",
+    author: {
+      "@type": "Person",
+      name: "SouravInsights",
+    },
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: channels.map((channel, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: channel.name,
+      })),
+    },
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 p-4 sm:p-2 md:p-8 transition-colors duration-200">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <h1 className="text-3xl sm:text-4xl font-bold text-center mb-2 sm:mb-4 text-green-800 dark:text-green-400 transition-colors duration-200">
         My Digital Garden
       </h1>


### PR DESCRIPTION
Introduced Next.js metadata for SEO and social sharing, and added a JSON-LD schema for enhanced search engine visibility. Also updated revalidation interval to 60 seconds for more frequent content updates.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces metadata and structured data for the `CuratedLinksPage`, enhancing SEO and providing information for social sharing. It also sets a revalidation time for the page.

### Detailed summary
- Added `revalidate` constant set to 60 seconds.
- Introduced `metadata` object with title, description, and Open Graph data.
- Created a `jsonLd` object for structured data with schema details.
- Included a `<script>` tag to embed the `jsonLd` in the page.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->